### PR TITLE
add loadAsync property

### DIFF
--- a/px-view.html
+++ b/px-view.html
@@ -45,6 +45,19 @@
           type: Boolean,
           value: false
         },
+        
+        /**
+         *
+         * Set to true to load this view asynchronously.
+         *
+         * @attribute loadAsync
+         * @type Boolean
+         * @default false
+        */
+        loadAsync: {
+          type: Boolean,
+          value: false
+        },
         /**
          *
          * Status tracks a px-view component over it's lifecycle
@@ -232,7 +245,7 @@
             }
           }, function(error) {
             this.set('status', 'failed');
-          });
+          }, this.loadAsync);
         }
       },
 


### PR DESCRIPTION
In the future, we may want to remove this component, but until then we should at least allow async loading of px-views.  This PR allows users to opt-in to async loading if desired.

@randyaskin @runn-vermel Please take a look when you have time.  Thanks!