### PR TITLE
feat: properties to restamp the view element

### DIFF
--- a/px-view.html
+++ b/px-view.html
@@ -45,7 +45,7 @@
           type: Boolean,
           value: false
         },
-        
+
         /**
          *
          * Set to true to load this view asynchronously.
@@ -58,6 +58,20 @@
           type: Boolean,
           value: false
         },
+
+        /**
+         * Remove from dom when this view element is not active, and re-create DOM
+         * elements when this element is active.
+         *
+         * @attribute restamp
+         * @type Boolean
+         * @default false
+         */
+        restamp: {
+          type: Boolean,
+          value: false
+        },
+
         /**
          *
          * Status tracks a px-view component over it's lifecycle
@@ -181,7 +195,11 @@
         if (this.active) {
           this._element.style.display = this.display;
         } else {
-          this.set('status', 'hidden');
+          if(this.restamp) {
+            this._resetView();
+          } else {
+            this.set('status', 'hidden');
+          }
         }
       },
 


### PR DESCRIPTION
Make it possible to re-stamp the element, even if the tag name remains unchanged, this is needed when we need to re-create the element, e.g. have to trigger the "ready" callback inside that element.